### PR TITLE
Enable support for Raspberry Pi camera

### DIFF
--- a/meta-polarsys/conf/layer.conf
+++ b/meta-polarsys/conf/layer.conf
@@ -10,3 +10,7 @@ BBFILE_PATTERN_polarsys := "^${LAYERDIR}/"
 BBFILE_PRIORITY_polarsys = "9"
 
 DISTRO_FEATURES_remove = " x11"
+DISTRO_FEATURES_remove = "wayland"
+
+# Enable Raspberry Pi camera
+VIDEO_CAMERA = "1"

--- a/meta-polarsys/recipes-core/images/polarsys-img.bb
+++ b/meta-polarsys/recipes-core/images/polarsys-img.bb
@@ -17,6 +17,7 @@ IMAGE_INSTALL += " \
     libmosquitto1 \
     libmosquittopp1 \
     mosquitto-clients \
+    userland \
 "
 
 SPLASH = "psplash-raspberrypi"


### PR DESCRIPTION
I think that is all that is needed in order to use the camera.  I was able to take a picture using raspistill.

The "userland" package provides the userspace tools (raspicam).  Enabling VIDEO_CAMERA makes the raspberry pi layer put start_x=1 in the boot config.txt, which selects the alternate start_x.elf firmware for bcm2835 (I believe).
