### PR TITLE
Add RTIMULib for the sensor hat

### DIFF
--- a/meta-polarsys/recipes-core/images/polarsys-img.bb
+++ b/meta-polarsys/recipes-core/images/polarsys-img.bb
@@ -19,6 +19,7 @@ IMAGE_INSTALL += " \
     libmosquittopp1 \
     mosquitto-clients \
     userland \
+    rtimulib \
 "
 
 SPLASH = "psplash-raspberrypi"

--- a/meta-polarsys/recipes-core/rtimulib/rtimulib_git.bb
+++ b/meta-polarsys/recipes-core/rtimulib/rtimulib_git.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "RTIMULib is a C++ and Python library that makes it easy to use 9-dof and \
+10-dof IMUs with embedded Linux systems"
+HOMEPAGE = "https://github.com/RPi-Distro/RTIMULib/"
+SECTION = "devel"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=96cdecb41125f498958e09b72faf318e"
+
+SRC_URI = "git://github.com/RPi-Distro/RTIMULib.git;protocol=http;branch=master \
+          "
+
+SRCREV = "b949681af69b45f0f7f4bb53b6770037b5b02178"
+
+S = "${WORKDIR}/git/RTIMULib"
+
+inherit cmake
+


### PR DESCRIPTION
This library is required to read sensor the values. It uses the i2c device for
communication.

Signed-off-by: Francis Giraldeau francis.giraldeau@gmail.com
