### PR TITLE
Enable build of protobuf compiler

### DIFF
--- a/meta-polarsys/recipes-core/images/polarsys-img.bb
+++ b/meta-polarsys/recipes-core/images/polarsys-img.bb
@@ -21,6 +21,8 @@ IMAGE_INSTALL += " \
     userland \
 "
 
+TOOLCHAIN_HOST_TASK += "nativesdk-protobuf-compiler"
+
 SPLASH = "psplash-raspberrypi"
 
 IMAGE_FEATURES += " \


### PR DESCRIPTION
This makes available the host side of protobuf, the protobuf compiler
"protoc".  It can be used by application developers to compile .proto
files to source code.

Signed-off-by: Simon Marchi simon.marchi@polymtl.ca
